### PR TITLE
amp runtime should respect the whitelist of actions specified in meta

### DIFF
--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -68,6 +68,13 @@ export class StandardActions {
     /** @const @private {!./viewport/viewport-impl.Viewport} */
     this.viewport_ = Services.viewportForDoc(ampdoc);
 
+    const meta =
+        window.document.head.querySelector('meta[name="amp-action-whitelist"]');
+    if (meta) {
+      /** @const @private {Array<string>} */
+      this.ampActionWhitelist_ = meta.getAttribute('content').split(',');
+    }
+
     this.installActions_(this.actions_);
   }
 
@@ -101,10 +108,14 @@ export class StandardActions {
    * @param {number=} opt_actionIndex
    * @param {!Array<!./action-impl.ActionInfoDef>=} opt_actionInfos
    * @return {?Promise}
-   * @throws {Error} If action is not recognized.
+   * @throws {Error} If action is not recognized or is not whitelisted.
    */
   handleAmpTarget(invocation, opt_actionIndex, opt_actionInfos) {
     const method = invocation.method;
+    if (this.ampActionWhitelist_ &&
+      this.ampActionWhitelist_.indexOf(method) == -1) {
+      throw user().createError('AMP action', method, 'is not whitelisted');
+    }
     switch (method) {
       case 'pushState':
       case 'setState':

--- a/test/functional/test-standard-actions.js
+++ b/test/functional/test-standard-actions.js
@@ -20,6 +20,7 @@ import {StandardActions} from '../../src/service/standard-actions-impl';
 import {Services} from '../../src/services';
 import {installHistoryServiceForDoc} from '../../src/service/history-impl';
 import {setParentWindow} from '../../src/service';
+import {createElementWithAttributes} from '../../src/dom';
 
 
 describes.sandboxed('StandardActions', {}, () => {
@@ -351,6 +352,66 @@ describes.sandboxed('StandardActions', {}, () => {
       };
       standardActions.handleAmpTarget(invocation);
       expect(printStub).to.be.calledOnce;
+    });
+
+    it('should not implement print when not whitelisted', () => {
+      window.document.head.appendChild(
+          createElementWithAttributes(window.document, 'meta', {
+            name: 'amp-action-whitelist',
+            content: 'pushState,setState',
+          }));
+
+      ampdoc = new AmpDocSingle(window);
+      standardActions = new StandardActions(ampdoc);
+
+      const windowApi = {
+        print: () => {},
+      };
+      const printStub = sandbox.stub(windowApi, 'print');
+      const invocation = {
+        method: 'print',
+        satisfiesTrust: () => true,
+        target: {
+          ownerDocument: {
+            defaultView: windowApi,
+          },
+        },
+      };
+      expect(() => {standardActions.handleAmpTarget(invocation);}).to.throw();
+      expect(printStub).to.not.be.called;
+    });
+
+    it('should implement psuhState when whitelisted', () => {
+      window.document.head.appendChild(
+          createElementWithAttributes(window.document, 'meta', {
+            name: 'amp-action-whitelist',
+            content: 'pushState',
+          }));
+
+      ampdoc = new AmpDocSingle(window);
+      standardActions = new StandardActions(ampdoc);
+
+      const pushStateWithExpression = sandbox.stub();
+      // Bind.pushStateWithExpression() doesn't resolve with a value,
+      // but add one here to check that the promise is chained.
+      pushStateWithExpression.returns(Promise.resolve('push-state-complete'));
+
+      window.services.bind = {
+        obj: {pushStateWithExpression},
+      };
+
+      const args = {
+        [OBJECT_STRING_ARGS_KEY]: '{foo: 123}',
+      };
+      const target = ampdoc;
+      const satisfiesTrust = () => true;
+      const pushState = {method: 'pushState', args, target, satisfiesTrust};
+
+      return standardActions.handleAmpTarget(pushState, 0, []).then(result => {
+        expect(result).to.equal('push-state-complete');
+        expect(pushStateWithExpression).to.be.calledOnce;
+        expect(pushStateWithExpression).to.be.calledWith('{foo: 123}');
+      });
     });
   });
 


### PR DESCRIPTION
If a whitelist of actions allowed on AMP target is specified using meta tags for example as follows

then the runtime should respect it. In order to do this we parse the meta tag in StandardActions. In handleAmpTarget we ensure a given action is whitelisted before triggering it.